### PR TITLE
feat: add Babel macro for shallowMock

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,50 @@ Object.assign(global, {
 
 ## Usage
 
-Unlike `enzyme#shallow` or `react-test-renderer/shallow`, this library performs selective shallow rendering. Developers choose specific components to shallow render by mocking them. There are two ways to mock a component:
+Unlike `enzyme#shallow` or `react-test-renderer/shallow`, this library performs selective shallow rendering. Developers choose specific components to shallow render by mocking them.
 
-### 1. `shallowWrapper`, `shallowed` and `jest.mock`
+### 1. Babel Macro (Recommended)
+
+The Babel macro provides a cleaner syntax by transforming your code at compile time.
+
+#### Installation
+
+1. Install `babel-plugin-macros`:
+
+```bash
+npm install babel-plugin-macros --save-dev
+```
+
+2. Add `macros` plugin to your Babel config:
+
+**babel.config.js**
+
+```javascript
+module.exports = {
+  plugins: ["macros"],
+};
+```
+
+#### Usage
+
+```typescript
+import { shallowMock } from "jest-shallow-serializer/macro";
+
+shallowMock("@/components/component-name", "ComponentName");
+```
+
+The macro transforms this at compile time into:
+
+```typescript
+jest.mock(
+  "@/components/component-name",
+  shallowWrapper("@/components/component-name", "ComponentName")
+);
+```
+
+**Note:** The first argument must be a string literal (the module path).
+
+### 2. `shallowWrapper` + `shallowed` + `jest.mock`
 
 ```typescript
 import * as componentModule from "@/app/module/Component";
@@ -79,7 +120,7 @@ jest.mock(
 const shallowedComponentModule = shallowed(componentModule);
 ```
 
-### 2. `doShallow` + `require`
+### 3. `doShallow` + `require`
 
 `doShallow` use `jest.doMock`, which is not hoisted, that's why we need to `require` shallowed module afterwards.
 
@@ -116,52 +157,19 @@ describe("Component", () => {
 });
 ```
 
-### 3. Babel Macro (Recommended)
+## Next.js
 
-The Babel macro provides a cleaner syntax by transforming your code at compile time.
-
-#### Installation
-
-1. Install `babel-plugin-macros`:
-
-```bash
-npm install babel-plugin-macros --save-dev
-```
-
-2. Add `macros` plugin to your Babel config:
-
-**babel.config.js**
+If you're using Next.js, add the `macros` plugin to your Babel config:
 
 ```javascript
+// babel.config.js
 module.exports = {
+  presets: ["next/babel"],
   plugins: ["macros"],
 };
 ```
 
-#### Usage
-
-Instead of writing:
-
-```typescript
-import { shallowWrapper } from "jest-shallow-serializer";
-
-jest.mock(
-  "@/components/component-name",
-  shallowWrapper("@/components/component-name", "ComponentName")
-);
-```
-
-You can simply write:
-
-```typescript
-import { shallowMock } from "jest-shallow-serializer/macro";
-
-shallowMock("@/components/component-name", "ComponentName");
-```
-
-The macro transforms this at compile time into the equivalent `jest.mock` call shown above.
-
-**Note:** The first argument must be a string literal (the module path).
+This works with both the App Router and Pages Router.
 
 ## Nested exports / Context
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A flexible jest serializer for shallow rendering React components. Unlike full shallow renderers, this tool focuses on serializing only the components you pick, making snapshots cleaner and more focused. Perfect for targeted testing with minimal noise! 🚀
 
+## Features
+
+- **Selective shallow rendering** - Choose which components to shallow render
+- **Babel macro support** - Compile-time transformation for cleaner test files
+- **Nested component support** - Mock context providers and nested exports
+- **No external dependencies** - Works with Jest's built-in mocking
+
 ## Motivation
 
 I created this package because existing solutions for shallow rendering are no longer maintained, and the testing ecosystem seems to be shifting toward other approaches. However, I still believe shallow rendering is a valuable technique for isolating and testing components effectively, and this serializer aims to fill that gap.
@@ -108,6 +115,53 @@ describe("Component", () => {
   });
 });
 ```
+
+### 3. Babel Macro (Recommended)
+
+The Babel macro provides a cleaner syntax by transforming your code at compile time.
+
+#### Installation
+
+1. Install `babel-plugin-macros`:
+
+```bash
+npm install babel-plugin-macros --save-dev
+```
+
+2. Add `macros` plugin to your Babel config:
+
+**babel.config.js**
+
+```javascript
+module.exports = {
+  plugins: ["macros"],
+};
+```
+
+#### Usage
+
+Instead of writing:
+
+```typescript
+import { shallowWrapper } from "jest-shallow-serializer";
+
+jest.mock(
+  "@/components/component-name",
+  shallowWrapper("@/components/component-name", "ComponentName")
+);
+```
+
+You can simply write:
+
+```typescript
+import { shallowMock } from "jest-shallow-serializer/macro";
+
+shallowMock("@/components/component-name", "ComponentName");
+```
+
+The macro transforms this at compile time into the equivalent `jest.mock` call shown above.
+
+**Note:** The first argument must be a string literal (the module path).
 
 ## Nested exports / Context
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["macros"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jest-shallow-serializer",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-shallow-serializer",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@babel/parser": "7.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/parser": "7.29.0",
         "@babel/traverse": "7.29.0",
         "@babel/types": "7.29.0",
+        "babel-plugin-macros": "3.1.0",
         "jest": "30.2.0",
         "json-stringify-safe": "5.0.1",
         "lodash.escape": "4.0.1",
@@ -24,10 +25,14 @@
         "set-value": "4.1.0"
       },
       "devDependencies": {
+        "@babel/core": "7.29.0",
+        "@babel/plugin-transform-typescript": "7.28.6",
+        "@babel/preset-typescript": "7.28.5",
         "@swc/core": "1.15.11",
         "@swc/jest": "0.2.39",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
+        "@types/babel-plugin-macros": "^3.1.3",
         "@types/jest": "30.0.0",
         "@types/json-stringify-safe": "5.0.3",
         "@types/lodash.escape": "4.0.9",
@@ -139,6 +144,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
@@ -164,11 +182,47 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -203,11 +257,56 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -489,11 +588,67 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
       "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1776,6 +1931,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/babel-plugin-macros": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/babel-plugin-macros/-/babel-plugin-macros-3.1.3.tgz",
+      "integrity": "sha512-JU+MgpsHK3taY18mBETy5XlwY6LVngte7QXYzUuXEaaX0CN8dBqbjXtADe+gJmkSQE1FJHufzPj++OWZlhRmGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1875,6 +2040,12 @@
       "dependencies": {
         "undici-types": "~7.12.0"
       }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -2321,6 +2492,22 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
@@ -2585,6 +2772,22 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2935,6 +3138,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2987,6 +3199,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -3058,6 +3282,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -3118,6 +3367,21 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -4649,6 +4913,18 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -4702,6 +4978,21 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4854,6 +5145,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -5130,6 +5441,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {
@@ -5622,6 +5945,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@swc/jest": "0.2.39",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
-        "@types/babel-plugin-macros": "^3.1.3",
+        "@types/babel-plugin-macros": "3.1.3",
         "@types/jest": "30.0.0",
         "@types/json-stringify-safe": "5.0.3",
         "@types/lodash.escape": "4.0.9",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@swc/jest": "0.2.39",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
-    "@types/babel-plugin-macros": "^3.1.3",
+    "@types/babel-plugin-macros": "3.1.3",
     "@types/jest": "30.0.0",
     "@types/json-stringify-safe": "5.0.3",
     "@types/lodash.escape": "4.0.9",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "main": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./serializer": "./dist/serializer.js"
+    "./serializer": "./dist/serializer.js",
+    "./macro": "./dist/macro.js"
   },
   "files": [
     "dist"
@@ -47,6 +48,7 @@
     "@babel/parser": "7.29.0",
     "@babel/traverse": "7.29.0",
     "@babel/types": "7.29.0",
+    "babel-plugin-macros": "3.1.0",
     "jest": "30.2.0",
     "json-stringify-safe": "5.0.1",
     "lodash.escape": "4.0.1",
@@ -59,10 +61,14 @@
     "set-value": "4.1.0"
   },
   "devDependencies": {
+    "@babel/core": "7.29.0",
+    "@babel/plugin-transform-typescript": "7.28.6",
+    "@babel/preset-typescript": "7.28.5",
     "@swc/core": "1.15.11",
     "@swc/jest": "0.2.39",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
+    "@types/babel-plugin-macros": "^3.1.3",
     "@types/jest": "30.0.0",
     "@types/json-stringify-safe": "5.0.3",
     "@types/lodash.escape": "4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-shallow-serializer",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "engines": {
     "node": ">= 20.18.1"
   },

--- a/src/__tests__/__snapshots__/macro.spec.ts.snap
+++ b/src/__tests__/__snapshots__/macro.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`macro transforms shallowMock to jest.mock 1`] = `"jest.mock("@/components/TestComponent", shallowWrapper("@/components/TestComponent", "TestComponent"));"`;

--- a/src/__tests__/macro.spec.ts
+++ b/src/__tests__/macro.spec.ts
@@ -1,0 +1,61 @@
+import * as babel from "@babel/core";
+import * as path from "path";
+
+const macroPath = path.resolve(__dirname, "../macro");
+const shallowMockMacro = require(macroPath).default;
+
+describe("macro", () => {
+  it("transforms shallowMock to jest.mock", () => {
+    const code = `
+import shallowMock from "${macroPath.replace(/\\/g, "/")}";
+
+shallowMock("@/components/TestComponent", "TestComponent");
+`;
+
+    const result = babel.transformSync(code, {
+      filename: "test.ts",
+      plugins: [
+        ["macros", { shallowMock: shallowMockMacro }],
+        "@babel/plugin-transform-typescript",
+      ],
+    });
+
+    expect(result?.code).toMatchSnapshot();
+  });
+
+  it("throws error when shallowMock is not called as function", () => {
+    const code = `
+import shallowMock from "${macroPath.replace(/\\/g, "/")}";
+
+const x = shallowMock;
+`;
+
+    expect(() => {
+      babel.transformSync(code, {
+        filename: "test.ts",
+        plugins: [
+          ["macros", { shallowMock: shallowMockMacro }],
+          "@babel/plugin-transform-typescript",
+        ],
+      });
+    }).toThrow("shallowMock must be called as a function");
+  });
+
+  it("throws error when module path is missing", () => {
+    const code = `
+import shallowMock from "${macroPath.replace(/\\/g, "/")}";
+
+shallowMock();
+`;
+
+    expect(() => {
+      babel.transformSync(code, {
+        filename: "test.ts",
+        plugins: [
+          ["macros", { shallowMock: shallowMockMacro }],
+          "@babel/plugin-transform-typescript",
+        ],
+      });
+    }).toThrow("shallowMock requires a module path");
+  });
+});

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -1,0 +1,41 @@
+import { createMacro, MacroParams } from "babel-plugin-macros";
+
+export default createMacro(shallowMockMacro);
+
+function shallowMockMacro({ references, babel }: MacroParams) {
+  const { types } = babel;
+  const refs = references.default || references.shallowMock;
+
+  refs.forEach((refPath) => {
+    const callPath = refPath.parentPath;
+
+    if (!callPath?.isCallExpression()) {
+      throw new Error("shallowMock must be called as a function");
+    }
+
+    const args = callPath.node.arguments;
+
+    if (args.length < 1) {
+      throw new Error("shallowMock requires a module path");
+    }
+
+    const modulePath = args[0];
+    const componentNames = args.slice(1);
+
+    const jestMockCall = types.callExpression(
+      types.memberExpression(
+        types.identifier("jest"),
+        types.identifier("mock"),
+      ),
+      [
+        modulePath,
+        types.callExpression(types.identifier("shallowWrapper"), [
+          modulePath,
+          ...componentNames,
+        ]),
+      ],
+    );
+
+    callPath.replaceWith(jestMockCall);
+  });
+}


### PR DESCRIPTION
Introduces `shallowMock` macro that transforms at compile time:
- Transforms `shallowMock(path, "ComponentName")` to `jest.mock(path, shallowWrapper(...))`
- Adds `src/macro.ts` with Babel macro implementation
- Updates `README.md` with macro documentation
- Requires `babel-plugin-macros` and `macros` in babel config